### PR TITLE
自动指纹：修复非全屏模式截图，支持非16:9屏幕比例

### DIFF
--- a/扩展插件/自动骇入指纹/GTAFingerprinterCore/Implementions/WinApiScreenCapture.cs
+++ b/扩展插件/自动骇入指纹/GTAFingerprinterCore/Implementions/WinApiScreenCapture.cs
@@ -1,10 +1,7 @@
-﻿using ControlzEx.Standard;
-using GTAFingerprinterCore.Interfaces;
-using GTAFingerprinterCore.Pages;
+﻿using GTAFingerprinterCore.Interfaces;
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using Windows.ApplicationModel.Background;
 
 namespace GTAFingerprinterCore.Implementions
 {


### PR DESCRIPTION
目前的实现在GTA窗口模式下无法截屏，会获取到黑屏。
此外，由于显示比例不是16:9时，GTA会在屏幕两侧显示黑边，影响判定。

考虑到玩家骇入指纹时，GTA窗口必须在前台，此PR将截图逻辑更改为先获取桌面截图，然后再截取GTA窗口位置的图片。
对于非全屏模式，会移除黑边。（TODO：可能需要对全屏模式也执行此操作以适配其它显示器比例。但我没有此类显示器）